### PR TITLE
Fix: Use correct 'Title' column for CIP positions table

### DIFF
--- a/dashboard.html
+++ b/dashboard.html
@@ -109,7 +109,7 @@
         tbody.innerHTML = '';
         results.data.forEach(row => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${row['CIP Code']}</td><td>${row['Position Title']}</td>`;
+          tr.innerHTML = `<td>${row['CIP Code']}</td><td>${row['Title']}</td>`;
           tbody.appendChild(tr);
         });
       }

--- a/index.html
+++ b/index.html
@@ -109,7 +109,7 @@
         tbody.innerHTML = '';
         results.data.forEach(row => {
           const tr = document.createElement('tr');
-          tr.innerHTML = `<td>${row['CIP Code']}</td><td>${row['Position Title']}</td>`;
+          tr.innerHTML = `<td>${row['CIP Code']}</td><td>${row['Title']}</td>`;
           tbody.appendChild(tr);
         });
       }


### PR DESCRIPTION
Updated the JavaScript in index.html and dashboard.html to use `row['Title']` instead of `row['Position Title']` when accessing data from the parsed CSV. This resolves an issue where titles were displaying as 'undefined' in the CIP Code Positions Reference table.