### PR TITLE
Adjust chart container height and add overflow hidden

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -31,7 +31,8 @@ body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f4f4f
 }
 .chart {
   position: relative; /* Added for better chart responsiveness */
-  height: 400px; /* Added to constrain chart height */
+  height: 480px; /* Increased height to better fit content */
+  overflow: hidden; /* Prevents content from overlapping other elements */
 }
 .chart canvas {
   max-width: 100%;


### PR DESCRIPTION
Increased .chart container height to 480px and added overflow: hidden to prevent charts from visibly overflowing their containers and overlapping other elements. This is an attempt to fix issues where chart bottoms were pushing down and overlapping.