### PR TITLE
Reduce chart font sizes and increase container height

### DIFF
--- a/assets/style.css
+++ b/assets/style.css
@@ -31,7 +31,7 @@ body { font-family: Arial, sans-serif; margin: 0; padding: 0; background: #f4f4f
 }
 .chart {
   position: relative; /* Added for better chart responsiveness */
-  height: 480px; /* Increased height to better fit content */
+  height: 500px; /* Further increased height to better fit content */
   overflow: hidden; /* Prevents content from overlapping other elements */
 }
 .chart canvas {

--- a/index.html
+++ b/index.html
@@ -79,7 +79,24 @@
               { label: 'New Certs', data: certs, backgroundColor: 'rgba(54, 162, 235, 0.5)' }
             ]
           },
-          options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              y: {
+                beginAtZero: true,
+                ticks: { font: { size: 10 } }
+              },
+              x: {
+                ticks: { font: { size: 10 } }
+              }
+            },
+            plugins: {
+              legend: {
+                labels: { font: { size: 10 } }
+              }
+            }
+          }
         });
       }
     });
@@ -100,7 +117,25 @@
             labels: institutions,
             datasets: [{ label: 'Graduates', data: grads, backgroundColor: 'rgba(75, 192, 192, 0.5)' }]
           },
-          options: { indexAxis: 'y', responsive: true, maintainAspectRatio: false, scales: { x: { beginAtZero: true } } }
+          options: {
+            indexAxis: 'y',
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              x: {
+                beginAtZero: true,
+                ticks: { font: { size: 10 } }
+              },
+              y: {
+                ticks: { font: { size: 10 } }
+              }
+            },
+            plugins: {
+              legend: {
+                labels: { font: { size: 10 } }
+              }
+            }
+          }
         });
       }
     });
@@ -126,7 +161,24 @@
               { label: 'Age 60-64', data: retire60_64, borderColor: 'rgba(153, 102, 255, 1)', fill: false }
             ]
           },
-          options: { responsive: true, maintainAspectRatio: false, scales: { y: { beginAtZero: true } } }
+          options: {
+            responsive: true,
+            maintainAspectRatio: false,
+            scales: {
+              y: {
+                beginAtZero: true,
+                ticks: { font: { size: 10 } }
+              },
+              x: {
+                ticks: { font: { size: 10 } }
+              }
+            },
+            plugins: {
+              legend: {
+                labels: { font: { size: 10 } }
+              }
+            }
+          }
         });
       }
     });


### PR DESCRIPTION
- Reduced font sizes for ticks and legends in all charts to 10pt.
- Increased .chart container height to 500px.

These changes aim to make the chart content smaller and provide enough container space to prevent data clipping and overlap.